### PR TITLE
Fix Initial Focus

### DIFF
--- a/lib/focus.directive.js
+++ b/lib/focus.directive.js
@@ -269,6 +269,13 @@ exports.default = {
                     focusElement.focus();
                 }
             },
+            inserted: function (el, binding, vnode) {
+                if (vnode.elm) {
+                    var focusElement = exports.navigationService.getFocusElementById(vnode.elm.id);
+                    if (focusElement && focusElement.isFocus)
+                        focusElement.focus();
+                }
+            },
             unbind: function (el, binding, vnode) {
                 if (vnode.elm) {
                     var focusElement = exports.navigationService.getFocusElementById(vnode.elm.id);

--- a/src/focus.directive.ts
+++ b/src/focus.directive.ts
@@ -294,6 +294,13 @@ export default {
           focusElement.focus();
         }
       },
+      inserted: (el: any, binding: any, vnode: VNode) => {
+        if (vnode.elm) {
+          let focusElement = navigationService.getFocusElementById((<HTMLScriptElement>vnode.elm).id);
+          if (focusElement && focusElement.isFocus)
+            focusElement.focus();
+        }
+      },
       unbind: (el: any, binding: any, vnode: VNode) => {
         if (vnode.elm) {
           let focusElement = navigationService.getFocusElementById((<HTMLScriptElement>vnode.elm).id);


### PR DESCRIPTION
The initial/default focus didn't add the "focus" class to the element because $el of the FocusElement will be undefined in bind().