### PR TITLE
Trigger Regular Click if listener is missing

### DIFF
--- a/lib/focus.directive.js
+++ b/lib/focus.directive.js
@@ -211,6 +211,9 @@ var FocusElement = /** @class */ (function () {
             }
             catch (e) { }
         }
+        else {
+            this.$el.click();
+        }
     };
     FocusElement.prototype.defaultFocusNext = function () {
         if (this.$el) {

--- a/src/focus.directive.ts
+++ b/src/focus.directive.ts
@@ -234,6 +234,8 @@ export class FocusElement {
       try {
         this.$el.__vue__.$vnode.componentOptions.listeners.click();
       } catch (e) {}
+    } else {
+      this.$el.click();
     }
   }
 


### PR DESCRIPTION
This fixes triggering the click event for cases like the following where the focused element is not a component:
```
<li v-focus v-on:click="...">...</li>
```